### PR TITLE
[Feature] Log forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # systemd-runtime
 container runtime integrated with systemd
+
+# dependencies
+run sh below to install btrfs deps
+```shell
+sudo apt install libbtrfs-dev
+sudo apt install btrfs-progs
+```

--- a/common/cleanup.go
+++ b/common/cleanup.go
@@ -9,10 +9,10 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/containerd/containerd/mount"
-	"github.com/containerd/containerd/pkg/process"
 	shimapi "github.com/containerd/containerd/runtime/v2/task"
 	goRunc "github.com/containerd/go-runc"
 
+	"github.com/projecteru2/systemd-runtime/process"
 	"github.com/projecteru2/systemd-runtime/runc"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -15,12 +15,12 @@ require (
 	github.com/containerd/zfs v1.0.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/protobuf v1.4.3
+	github.com/hashicorp/go-multierror v1.0.0
 	github.com/opencontainers/image-spec v1.0.1
 	github.com/opencontainers/runtime-spec v1.0.3-0.20200929063507-e6143ca7d51d
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/urfave/cli v1.22.5 // indirect
-	github.com/urfave/cli/v2 v2.3.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20210525143221-35b2ab0089ea
 	google.golang.org/grpc v1.33.2

--- a/go.sum
+++ b/go.sum
@@ -591,8 +591,6 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/urfave/cli v1.22.1 h1:+mkCCcOFKPnCmVYVcURKps1Xe+3zP90gSYGNfRkjoIY=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
-github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
-github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/vishvananda/netlink v0.0.0-20181108222139-023a6dafdcdf/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
@@ -882,7 +880,6 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWD
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/process/deleted_state.go
+++ b/process/deleted_state.go
@@ -1,0 +1,76 @@
+//go:build !windows
+// +build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package process
+
+import (
+	"context"
+
+	"github.com/containerd/console"
+	"github.com/containerd/containerd/errdefs"
+	google_protobuf "github.com/gogo/protobuf/types"
+	"github.com/pkg/errors"
+)
+
+type deletedState struct {
+}
+
+func (s *deletedState) Pause(ctx context.Context) error {
+	return errors.Errorf("cannot pause a deleted process")
+}
+
+func (s *deletedState) Resume(ctx context.Context) error {
+	return errors.Errorf("cannot resume a deleted process")
+}
+
+func (s *deletedState) Update(context context.Context, r *google_protobuf.Any) error {
+	return errors.Errorf("cannot update a deleted process")
+}
+
+func (s *deletedState) Checkpoint(ctx context.Context, r *CheckpointConfig) error {
+	return errors.Errorf("cannot checkpoint a deleted process")
+}
+
+func (s *deletedState) Resize(ws console.WinSize) error {
+	return errors.Errorf("cannot resize a deleted process")
+}
+
+func (s *deletedState) Start(ctx context.Context) error {
+	return errors.Errorf("cannot start a deleted process")
+}
+
+func (s *deletedState) Delete(ctx context.Context) error {
+	return errors.Wrap(errdefs.ErrNotFound, "cannot delete a deleted process")
+}
+
+func (s *deletedState) Kill(ctx context.Context, sig uint32, all bool) error {
+	return errors.Wrap(errdefs.ErrNotFound, "cannot kill a deleted process")
+}
+
+func (s *deletedState) SetExited(status int) {
+	// no op
+}
+
+func (s *deletedState) Exec(ctx context.Context, path string, r *ExecConfig) (Process, error) {
+	return nil, errors.Errorf("cannot exec in a deleted state")
+}
+
+func (s *deletedState) Status(ctx context.Context) (string, error) {
+	return "stopped", nil //nolint:goconst
+}

--- a/process/exec.go
+++ b/process/exec.go
@@ -1,0 +1,263 @@
+//go:build !windows
+// +build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package process
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/containerd/console"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/pkg/stdio"
+	"github.com/containerd/fifo"
+	runc "github.com/containerd/go-runc"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
+)
+
+type execProcess struct {
+	wg sync.WaitGroup
+
+	execState execState
+
+	mu      sync.Mutex
+	id      string
+	console console.Console
+	io      *processIO
+	status  int
+	exited  time.Time
+	pid     safePid
+	closers []io.Closer
+	stdin   io.Closer
+	stdio   stdio.Stdio
+	path    string
+	spec    specs.Process
+
+	parent    *Init
+	waitBlock chan struct{}
+}
+
+func (e *execProcess) Wait() {
+	<-e.waitBlock
+}
+
+func (e *execProcess) ID() string {
+	return e.id
+}
+
+func (e *execProcess) Pid() int {
+	return e.pid.get()
+}
+
+func (e *execProcess) ExitStatus() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.status
+}
+
+func (e *execProcess) ExitedAt() time.Time {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.exited
+}
+
+func (e *execProcess) SetExited(status int) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.execState.SetExited(status)
+}
+
+func (e *execProcess) setExited(status int) {
+	e.status = status
+	e.exited = time.Now()
+	e.parent.Platform.ShutdownConsole(context.Background(), e.console) //nolint:errcheck
+	close(e.waitBlock)
+}
+
+func (e *execProcess) Delete(ctx context.Context) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	return e.execState.Delete(ctx)
+}
+
+func (e *execProcess) delete(ctx context.Context) error {
+	waitTimeout(ctx, &e.wg, 2*time.Second) //nolint:errcheck
+	if e.io != nil {
+		for _, c := range e.closers {
+			c.Close()
+		}
+		e.io.Close()
+	}
+	pidfile := filepath.Join(e.path, fmt.Sprintf("%s.pid", e.id))
+	// silently ignore error
+	os.Remove(pidfile)
+	return nil
+}
+
+func (e *execProcess) Resize(ws console.WinSize) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	return e.execState.Resize(ws)
+}
+
+func (e *execProcess) resize(ws console.WinSize) error {
+	if e.console == nil {
+		return nil
+	}
+	return e.console.Resize(ws)
+}
+
+func (e *execProcess) Kill(ctx context.Context, sig uint32, _ bool) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	return e.execState.Kill(ctx, sig, false)
+}
+
+func (e *execProcess) kill(_ context.Context, sig uint32, _ bool) error {
+	pid := e.pid.get()
+	switch {
+	case pid == 0:
+		return errors.Wrap(errdefs.ErrFailedPrecondition, "process not created")
+	case !e.exited.IsZero():
+		return errors.Wrapf(errdefs.ErrNotFound, "process already finished")
+	default:
+		if err := unix.Kill(pid, syscall.Signal(sig)); err != nil {
+			return errors.Wrapf(checkKillError(err), "exec kill error")
+		}
+	}
+	return nil
+}
+
+func (e *execProcess) Stdin() io.Closer {
+	return e.stdin
+}
+
+func (e *execProcess) Stdio() stdio.Stdio {
+	return e.stdio
+}
+
+func (e *execProcess) Start(ctx context.Context) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	return e.execState.Start(ctx)
+}
+
+func (e *execProcess) start(ctx context.Context) (err error) {
+	// The reaper may receive exit signal right after
+	// the container is started, before the e.pid is updated.
+	// In that case, we want to block the signal handler to
+	// access e.pid until it is updated.
+	e.pid.Lock()
+	defer e.pid.Unlock()
+
+	var (
+		socket  *runc.Socket
+		pio     *processIO
+		pidFile = newExecPidFile(e.path, e.id)
+	)
+	if e.stdio.Terminal {
+		if socket, err = runc.NewTempConsoleSocket(); err != nil {
+			return errors.Wrap(err, "failed to create runc console socket")
+		}
+		defer socket.Close()
+	} else {
+		if pio, err = createIO(ctx, e.id, e.parent.IoUID, e.parent.IoGID, e.stdio); err != nil {
+			return errors.Wrap(err, "failed to create init process I/O")
+		}
+		e.io = pio
+	}
+	opts := &runc.ExecOpts{
+		PidFile: pidFile.Path(),
+		Detach:  true,
+	}
+	if pio != nil {
+		opts.IO = pio.IO()
+	}
+	if socket != nil {
+		opts.ConsoleSocket = socket
+	}
+	if err := e.parent.runtime.Exec(ctx, e.parent.id, e.spec, opts); err != nil {
+		close(e.waitBlock)
+		return e.parent.runtimeError(err, "OCI runtime exec failed")
+	}
+	if e.stdio.Stdin != "" {
+		if err := e.openStdin(e.stdio.Stdin); err != nil {
+			return err
+		}
+	}
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	if socket != nil {
+		console, err := socket.ReceiveMaster()
+		if err != nil {
+			return errors.Wrap(err, "failed to retrieve console master")
+		}
+		if e.console, err = e.parent.Platform.CopyConsole(ctx, console, e.id, e.stdio.Stdin, e.stdio.Stdout, e.stdio.Stderr, &e.wg); err != nil {
+			return errors.Wrap(err, "failed to start console copy")
+		}
+	} else if err := pio.Copy(ctx, &e.wg); err != nil {
+		return errors.Wrap(err, "failed to start io pipe copy")
+	}
+	pid, err := pidFile.Read()
+	if err != nil {
+		return errors.Wrap(err, "failed to retrieve OCI runtime exec pid")
+	}
+	e.pid.pid = pid
+	return nil
+}
+
+func (e *execProcess) openStdin(path string) error {
+	sc, err := fifo.OpenFifo(context.Background(), path, syscall.O_WRONLY|syscall.O_NONBLOCK, 0)
+	if err != nil {
+		return errors.Wrapf(err, "failed to open stdin fifo %s", path)
+	}
+	e.stdin = sc
+	e.closers = append(e.closers, sc)
+	return nil
+}
+
+func (e *execProcess) Status(ctx context.Context) (string, error) {
+	s, err := e.parent.Status(ctx)
+	if err != nil {
+		return "", err
+	}
+	// if the container as a whole is in the pausing/paused state, so are all
+	// other processes inside the container, use container state here
+	switch s {
+	case "paused", "pausing": //nolint:goconst
+		return s, nil
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.execState.Status(ctx)
+}

--- a/process/exec_state.go
+++ b/process/exec_state.go
@@ -1,0 +1,173 @@
+//go:build !windows
+// +build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package process
+
+import (
+	"context"
+
+	"github.com/containerd/console"
+	"github.com/pkg/errors"
+)
+
+type execState interface {
+	Resize(console.WinSize) error
+	Start(context.Context) error
+	Delete(context.Context) error
+	Kill(context.Context, uint32, bool) error
+	SetExited(int)
+	Status(context.Context) (string, error)
+}
+
+type execCreatedState struct {
+	p *execProcess
+}
+
+func (s *execCreatedState) transition(name string) error {
+	switch name {
+	case "running": //nolint:goconst
+		s.p.execState = &execRunningState{p: s.p}
+	case "stopped":
+		s.p.execState = &execStoppedState{p: s.p}
+	case "deleted": //nolint:goconst
+		s.p.execState = &deletedState{}
+	default:
+		return errors.Errorf("invalid state transition %q to %q", stateName(s), name)
+	}
+	return nil
+}
+
+func (s *execCreatedState) Resize(ws console.WinSize) error {
+	return s.p.resize(ws)
+}
+
+func (s *execCreatedState) Start(ctx context.Context) error {
+	if err := s.p.start(ctx); err != nil {
+		return err
+	}
+	return s.transition("running")
+}
+
+func (s *execCreatedState) Delete(ctx context.Context) error {
+	if err := s.p.delete(ctx); err != nil {
+		return err
+	}
+
+	return s.transition("deleted")
+}
+
+func (s *execCreatedState) Kill(ctx context.Context, sig uint32, all bool) error {
+	return s.p.kill(ctx, sig, all)
+}
+
+func (s *execCreatedState) SetExited(status int) {
+	s.p.setExited(status)
+
+	if err := s.transition("stopped"); err != nil {
+		panic(err)
+	}
+}
+
+func (s *execCreatedState) Status(ctx context.Context) (string, error) {
+	return "created", nil //nolint:goconst
+}
+
+type execRunningState struct {
+	p *execProcess
+}
+
+func (s *execRunningState) transition(name string) error {
+	switch name {
+	case "stopped":
+		s.p.execState = &execStoppedState{p: s.p}
+	default:
+		return errors.Errorf("invalid state transition %q to %q", stateName(s), name)
+	}
+	return nil
+}
+
+func (s *execRunningState) Resize(ws console.WinSize) error {
+	return s.p.resize(ws)
+}
+
+func (s *execRunningState) Start(ctx context.Context) error {
+	return errors.Errorf("cannot start a running process")
+}
+
+func (s *execRunningState) Delete(ctx context.Context) error {
+	return errors.Errorf("cannot delete a running process")
+}
+
+func (s *execRunningState) Kill(ctx context.Context, sig uint32, all bool) error {
+	return s.p.kill(ctx, sig, all)
+}
+
+func (s *execRunningState) SetExited(status int) {
+	s.p.setExited(status)
+
+	if err := s.transition("stopped"); err != nil {
+		panic(err)
+	}
+}
+
+func (s *execRunningState) Status(ctx context.Context) (string, error) {
+	return "running", nil
+}
+
+type execStoppedState struct {
+	p *execProcess
+}
+
+func (s *execStoppedState) transition(name string) error {
+	switch name {
+	case "deleted":
+		s.p.execState = &deletedState{}
+	default:
+		return errors.Errorf("invalid state transition %q to %q", stateName(s), name)
+	}
+	return nil
+}
+
+func (s *execStoppedState) Resize(ws console.WinSize) error {
+	return errors.Errorf("cannot resize a stopped container")
+}
+
+func (s *execStoppedState) Start(ctx context.Context) error {
+	return errors.Errorf("cannot start a stopped process")
+}
+
+func (s *execStoppedState) Delete(ctx context.Context) error {
+	if err := s.p.delete(ctx); err != nil {
+		return err
+	}
+
+	return s.transition("deleted")
+}
+
+func (s *execStoppedState) Kill(ctx context.Context, sig uint32, all bool) error {
+	return s.p.kill(ctx, sig, all)
+}
+
+func (s *execStoppedState) SetExited(status int) {
+	// no op
+}
+
+func (s *execStoppedState) Status(ctx context.Context) (string, error) {
+	return "stopped", nil
+}

--- a/process/init.go
+++ b/process/init.go
@@ -1,0 +1,498 @@
+//go:build !windows
+// +build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package process
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/containerd/console"
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/pkg/stdio"
+	"github.com/containerd/fifo"
+	runc "github.com/containerd/go-runc"
+	google_protobuf "github.com/gogo/protobuf/types"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+)
+
+// Init represents an initial process for a container
+type Init struct {
+	wg        sync.WaitGroup
+	initState initState
+
+	// mu is used to ensure that `Start()` and `Exited()` calls return in
+	// the right order when invoked in separate go routines.
+	// This is the case within the shim implementation as it makes use of
+	// the reaper interface.
+	mu sync.Mutex
+
+	waitBlock chan struct{}
+
+	WorkDir string
+
+	id       string
+	Bundle   string
+	console  console.Console
+	Platform stdio.Platform
+	io       *processIO
+	runtime  *runc.Runc
+	// pausing preserves the pausing state.
+	pausing      *atomicBool
+	status       int
+	exited       time.Time
+	pid          int
+	closers      []io.Closer
+	stdin        io.Closer
+	stdio        stdio.Stdio
+	Rootfs       string
+	IoUID        int
+	IoGID        int
+	NoPivotRoot  bool
+	NoNewKeyring bool
+	CriuWorkPath string
+}
+
+// NewRunc returns a new runc instance for a process
+func NewRunc(root, path, namespace, runtime, criu string, systemd bool) *runc.Runc {
+	if root == "" {
+		root = RuncRoot
+	}
+	return &runc.Runc{
+		Command:       runtime,
+		Log:           filepath.Join(path, "log.json"),
+		LogFormat:     runc.JSON,
+		PdeathSignal:  unix.SIGKILL,
+		Root:          filepath.Join(root, namespace),
+		Criu:          criu,
+		SystemdCgroup: systemd,
+	}
+}
+
+// New returns a new process
+func New(id string, runtime *runc.Runc, stdio stdio.Stdio) *Init {
+	p := &Init{
+		id:        id,
+		runtime:   runtime,
+		pausing:   new(atomicBool),
+		stdio:     stdio,
+		status:    0,
+		waitBlock: make(chan struct{}),
+	}
+	p.initState = &createdState{p: p}
+	return p
+}
+
+// Create the process with the provided config
+func (p *Init) Create(ctx context.Context, r *CreateConfig) error {
+	var (
+		err     error
+		socket  *runc.Socket
+		pio     *processIO
+		pidFile = newPidFile(p.Bundle)
+	)
+
+	if r.Terminal {
+		if socket, err = runc.NewTempConsoleSocket(); err != nil {
+			return errors.Wrap(err, "failed to create OCI runtime console socket")
+		}
+		defer socket.Close()
+	} else {
+		if pio, err = createIO(ctx, p.id, p.IoUID, p.IoGID, p.stdio); err != nil {
+			return errors.Wrap(err, "failed to create init process I/O")
+		}
+		p.io = pio
+	}
+	if r.Checkpoint != "" {
+		return p.createCheckpointedState(r, pidFile)
+	}
+	opts := &runc.CreateOpts{
+		PidFile:      pidFile.Path(),
+		NoPivot:      p.NoPivotRoot,
+		NoNewKeyring: p.NoNewKeyring,
+	}
+	if p.io != nil {
+		opts.IO = p.io.IO()
+	}
+	if socket != nil {
+		opts.ConsoleSocket = socket
+	}
+	if err := p.runtime.Create(ctx, r.ID, r.Bundle, opts); err != nil {
+		return p.runtimeError(err, "OCI runtime create failed")
+	}
+	if r.Stdin != "" {
+		if err := p.openStdin(r.Stdin); err != nil {
+			return err
+		}
+	}
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	if socket != nil {
+		console, err := socket.ReceiveMaster()
+		if err != nil {
+			return errors.Wrap(err, "failed to retrieve console master")
+		}
+		console, err = p.Platform.CopyConsole(ctx, console, p.id, r.Stdin, r.Stdout, r.Stderr, &p.wg)
+		if err != nil {
+			return errors.Wrap(err, "failed to start console copy")
+		}
+		p.console = console
+	} else if err := pio.Copy(ctx, &p.wg); err != nil {
+		return errors.Wrap(err, "failed to start io pipe copy")
+	}
+
+	pid, err := pidFile.Read()
+	if err != nil {
+		return errors.Wrap(err, "failed to retrieve OCI runtime container pid")
+	}
+	p.pid = pid
+	return nil
+}
+
+func (p *Init) openStdin(path string) error {
+	sc, err := fifo.OpenFifo(context.Background(), path, unix.O_WRONLY|unix.O_NONBLOCK, 0)
+	if err != nil {
+		return errors.Wrapf(err, "failed to open stdin fifo %s", path)
+	}
+	p.stdin = sc
+	p.closers = append(p.closers, sc)
+	return nil
+}
+
+func (p *Init) createCheckpointedState(r *CreateConfig, pidFile *pidFile) error {
+	opts := &runc.RestoreOpts{
+		CheckpointOpts: runc.CheckpointOpts{
+			ImagePath:  r.Checkpoint,
+			WorkDir:    p.CriuWorkPath,
+			ParentPath: r.ParentCheckpoint,
+		},
+		PidFile:     pidFile.Path(),
+		NoPivot:     p.NoPivotRoot,
+		Detach:      true,
+		NoSubreaper: true,
+	}
+
+	if p.io != nil {
+		opts.IO = p.io.IO()
+	}
+
+	p.initState = &createdCheckpointState{
+		p:    p,
+		opts: opts,
+	}
+	return nil
+}
+
+// Wait for the process to exit
+func (p *Init) Wait() {
+	<-p.waitBlock
+}
+
+// ID of the process
+func (p *Init) ID() string {
+	return p.id
+}
+
+// Pid of the process
+func (p *Init) Pid() int {
+	return p.pid
+}
+
+// ExitStatus of the process
+func (p *Init) ExitStatus() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.status
+}
+
+// ExitedAt at time when the process exited
+func (p *Init) ExitedAt() time.Time {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.exited
+}
+
+// Status of the process
+func (p *Init) Status(ctx context.Context) (string, error) {
+	if p.pausing.get() {
+		return "pausing", nil
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.initState.Status(ctx)
+}
+
+// Start the init process
+func (p *Init) Start(ctx context.Context) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.initState.Start(ctx)
+}
+
+func (p *Init) start(ctx context.Context) error {
+	err := p.runtime.Start(ctx, p.id)
+	return p.runtimeError(err, "OCI runtime start failed")
+}
+
+// SetExited of the init process with the next status
+func (p *Init) SetExited(status int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.initState.SetExited(status)
+}
+
+func (p *Init) setExited(status int) {
+	p.exited = time.Now()
+	p.status = status
+	p.Platform.ShutdownConsole(context.Background(), p.console) //nolint:errcheck
+	close(p.waitBlock)
+}
+
+// Delete the init process
+func (p *Init) Delete(ctx context.Context) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.initState.Delete(ctx)
+}
+
+func (p *Init) delete(ctx context.Context) error {
+	waitTimeout(ctx, &p.wg, 2*time.Second) //nolint:errcheck
+	err := p.runtime.Delete(ctx, p.id, nil)
+	// ignore errors if a runtime has already deleted the process
+	// but we still hold metadata and pipes
+	//
+	// this is common during a checkpoint, runc will delete the container state
+	// after a checkpoint and the container will no longer exist within runc
+	if err != nil {
+		if strings.Contains(err.Error(), "does not exist") {
+			err = nil
+		} else {
+			err = p.runtimeError(err, "failed to delete task")
+		}
+	}
+	if p.io != nil {
+		for _, c := range p.closers {
+			c.Close()
+		}
+		p.io.Close()
+	}
+	if err2 := mount.UnmountAll(p.Rootfs, 0); err2 != nil {
+		log.G(ctx).WithError(err2).Warn("failed to cleanup rootfs mount")
+		if err == nil {
+			err = errors.Wrap(err2, "failed rootfs umount")
+		}
+	}
+	return err
+}
+
+// Resize the init processes console
+func (p *Init) Resize(ws console.WinSize) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.console == nil {
+		return nil
+	}
+	return p.console.Resize(ws)
+}
+
+// Pause the init process and all its child processes
+func (p *Init) Pause(ctx context.Context) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.initState.Pause(ctx)
+}
+
+// Resume the init process and all its child processes
+func (p *Init) Resume(ctx context.Context) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.initState.Resume(ctx)
+}
+
+// Kill the init process
+func (p *Init) Kill(ctx context.Context, signal uint32, all bool) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.initState.Kill(ctx, signal, all)
+}
+
+func (p *Init) kill(ctx context.Context, signal uint32, all bool) error {
+	err := p.runtime.Kill(ctx, p.id, int(signal), &runc.KillOpts{
+		All: all,
+	})
+	return checkKillError(err)
+}
+
+// KillAll processes belonging to the init process
+func (p *Init) KillAll(ctx context.Context) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	err := p.runtime.Kill(ctx, p.id, int(unix.SIGKILL), &runc.KillOpts{
+		All: true,
+	})
+	return p.runtimeError(err, "OCI runtime killall failed")
+}
+
+// Stdin of the process
+func (p *Init) Stdin() io.Closer {
+	return p.stdin
+}
+
+// Runtime returns the OCI runtime configured for the init process
+func (p *Init) Runtime() *runc.Runc {
+	return p.runtime
+}
+
+// Exec returns a new child process
+func (p *Init) Exec(ctx context.Context, path string, r *ExecConfig) (Process, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.initState.Exec(ctx, path, r)
+}
+
+// exec returns a new exec'd process
+func (p *Init) exec(_ context.Context, path string, r *ExecConfig) (Process, error) {
+	// process exec request
+	var spec specs.Process
+	if err := json.Unmarshal(r.Spec.Value, &spec); err != nil {
+		return nil, err
+	}
+	spec.Terminal = r.Terminal
+
+	e := &execProcess{
+		id:     r.ID,
+		path:   path,
+		parent: p,
+		spec:   spec,
+		stdio: stdio.Stdio{
+			Stdin:    r.Stdin,
+			Stdout:   r.Stdout,
+			Stderr:   r.Stderr,
+			Terminal: r.Terminal,
+		},
+		waitBlock: make(chan struct{}),
+	}
+	e.execState = &execCreatedState{p: e}
+	return e, nil
+}
+
+// Checkpoint the init process
+func (p *Init) Checkpoint(ctx context.Context, r *CheckpointConfig) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.initState.Checkpoint(ctx, r)
+}
+
+func (p *Init) checkpoint(ctx context.Context, r *CheckpointConfig) error {
+	var actions []runc.CheckpointAction
+	if !r.Exit {
+		actions = append(actions, runc.LeaveRunning)
+	}
+	// keep criu work directory if criu work dir is set
+	work := r.WorkDir
+	if work == "" {
+		work = filepath.Join(p.WorkDir, "criu-work")
+		defer os.RemoveAll(work)
+	}
+	if err := p.runtime.Checkpoint(ctx, p.id, &runc.CheckpointOpts{
+		WorkDir:                  work,
+		ImagePath:                r.Path,
+		AllowOpenTCP:             r.AllowOpenTCP,
+		AllowExternalUnixSockets: r.AllowExternalUnixSockets,
+		AllowTerminal:            r.AllowTerminal,
+		FileLocks:                r.FileLocks,
+		EmptyNamespaces:          r.EmptyNamespaces,
+	}, actions...); err != nil {
+		dumpLog := filepath.Join(p.Bundle, "criu-dump.log")
+		if cerr := copyFile(dumpLog, filepath.Join(work, "dump.log")); cerr != nil {
+			log.G(ctx).WithError(cerr).Error("failed to copy dump.log to criu-dump.log")
+		}
+		return fmt.Errorf("%s path= %s", criuError(err), dumpLog)
+	}
+	return nil
+}
+
+// Update the processes resource configuration
+func (p *Init) Update(ctx context.Context, r *google_protobuf.Any) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.initState.Update(ctx, r)
+}
+
+func (p *Init) update(ctx context.Context, r *google_protobuf.Any) error {
+	var resources specs.LinuxResources
+	if err := json.Unmarshal(r.Value, &resources); err != nil {
+		return err
+	}
+	return p.runtime.Update(ctx, p.id, &resources)
+}
+
+// Stdio of the process
+func (p *Init) Stdio() stdio.Stdio {
+	return p.stdio
+}
+
+func (p *Init) runtimeError(rErr error, msg string) error {
+	if rErr == nil {
+		return nil
+	}
+
+	rMsg, err := getLastRuntimeError(p.runtime)
+	switch {
+	case err != nil:
+		return errors.Wrapf(rErr, "%s: %s (%s)", msg, "unable to retrieve OCI runtime error", err.Error())
+	case rMsg == "":
+		return errors.Wrap(rErr, msg)
+	default:
+		return errors.Errorf("%s: %s", msg, rMsg)
+	}
+}
+
+func withConditionalIO(c stdio.Stdio) runc.IOOpt {
+	return func(o *runc.IOOption) {
+		o.OpenStdin = c.Stdin != ""
+		o.OpenStdout = c.Stdout != ""
+		o.OpenStderr = c.Stderr != ""
+	}
+}

--- a/process/init_state.go
+++ b/process/init_state.go
@@ -1,0 +1,414 @@
+//go:build !windows
+// +build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package process
+
+import (
+	"context"
+
+	runc "github.com/containerd/go-runc"
+	google_protobuf "github.com/gogo/protobuf/types"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+type initState interface {
+	Start(context.Context) error
+	Delete(context.Context) error
+	Pause(context.Context) error
+	Resume(context.Context) error
+	Update(context.Context, *google_protobuf.Any) error
+	Checkpoint(context.Context, *CheckpointConfig) error
+	Exec(context.Context, string, *ExecConfig) (Process, error)
+	Kill(context.Context, uint32, bool) error
+	SetExited(int)
+	Status(context.Context) (string, error)
+}
+
+type createdState struct {
+	p *Init
+}
+
+func (s *createdState) transition(name string) error {
+	switch name {
+	case "running":
+		s.p.initState = &runningState{p: s.p}
+	case "stopped":
+		s.p.initState = &stoppedState{p: s.p}
+	case "deleted":
+		s.p.initState = &deletedState{}
+	default:
+		return errors.Errorf("invalid state transition %q to %q", stateName(s), name)
+	}
+	return nil
+}
+
+func (s *createdState) Pause(ctx context.Context) error {
+	return errors.Errorf("cannot pause task in created state")
+}
+
+func (s *createdState) Resume(ctx context.Context) error {
+	return errors.Errorf("cannot resume task in created state")
+}
+
+func (s *createdState) Update(ctx context.Context, r *google_protobuf.Any) error {
+	return s.p.update(ctx, r)
+}
+
+func (s *createdState) Checkpoint(ctx context.Context, r *CheckpointConfig) error {
+	return errors.Errorf("cannot checkpoint a task in created state")
+}
+
+func (s *createdState) Start(ctx context.Context) error {
+	if err := s.p.start(ctx); err != nil {
+		return err
+	}
+	return s.transition("running")
+}
+
+func (s *createdState) Delete(ctx context.Context) error {
+	if err := s.p.delete(ctx); err != nil {
+		return err
+	}
+	return s.transition("deleted")
+}
+
+func (s *createdState) Kill(ctx context.Context, sig uint32, all bool) error {
+	return s.p.kill(ctx, sig, all)
+}
+
+func (s *createdState) SetExited(status int) {
+	s.p.setExited(status)
+
+	if err := s.transition("stopped"); err != nil {
+		panic(err)
+	}
+}
+
+func (s *createdState) Exec(ctx context.Context, path string, r *ExecConfig) (Process, error) {
+	return s.p.exec(ctx, path, r)
+}
+
+func (s *createdState) Status(ctx context.Context) (string, error) {
+	return "created", nil
+}
+
+type createdCheckpointState struct {
+	p    *Init
+	opts *runc.RestoreOpts
+}
+
+func (s *createdCheckpointState) transition(name string) error {
+	switch name {
+	case "running":
+		s.p.initState = &runningState{p: s.p}
+	case "stopped":
+		s.p.initState = &stoppedState{p: s.p}
+	case "deleted":
+		s.p.initState = &deletedState{}
+	default:
+		return errors.Errorf("invalid state transition %q to %q", stateName(s), name)
+	}
+	return nil
+}
+
+func (s *createdCheckpointState) Pause(ctx context.Context) error {
+	return errors.Errorf("cannot pause task in created state")
+}
+
+func (s *createdCheckpointState) Resume(ctx context.Context) error {
+	return errors.Errorf("cannot resume task in created state")
+}
+
+func (s *createdCheckpointState) Update(ctx context.Context, r *google_protobuf.Any) error {
+	return s.p.update(ctx, r)
+}
+
+func (s *createdCheckpointState) Checkpoint(ctx context.Context, r *CheckpointConfig) error {
+	return errors.Errorf("cannot checkpoint a task in created state")
+}
+
+func (s *createdCheckpointState) Start(ctx context.Context) error {
+	p := s.p
+	sio := p.stdio
+
+	var (
+		err    error
+		socket *runc.Socket
+	)
+	if sio.Terminal {
+		if socket, err = runc.NewTempConsoleSocket(); err != nil {
+			return errors.Wrap(err, "failed to create OCI runtime console socket")
+		}
+		defer socket.Close()
+		s.opts.ConsoleSocket = socket
+	}
+
+	if _, err := s.p.runtime.Restore(ctx, p.id, p.Bundle, s.opts); err != nil {
+		return p.runtimeError(err, "OCI runtime restore failed")
+	}
+	if sio.Stdin != "" {
+		if err := p.openStdin(sio.Stdin); err != nil {
+			return errors.Wrapf(err, "failed to open stdin fifo %s", sio.Stdin)
+		}
+	}
+	if socket != nil {
+		console, err := socket.ReceiveMaster()
+		if err != nil {
+			return errors.Wrap(err, "failed to retrieve console master")
+		}
+		console, err = p.Platform.CopyConsole(ctx, console, p.id, sio.Stdin, sio.Stdout, sio.Stderr, &p.wg)
+		if err != nil {
+			return errors.Wrap(err, "failed to start console copy")
+		}
+		p.console = console
+	} else if err := p.io.Copy(ctx, &p.wg); err != nil {
+		return errors.Wrap(err, "failed to start io pipe copy")
+	}
+
+	pid, err := runc.ReadPidFile(s.opts.PidFile)
+	if err != nil {
+		return errors.Wrap(err, "failed to retrieve OCI runtime container pid")
+	}
+	p.pid = pid
+	return s.transition("running")
+}
+
+func (s *createdCheckpointState) Delete(ctx context.Context) error {
+	if err := s.p.delete(ctx); err != nil {
+		return err
+	}
+	return s.transition("deleted")
+}
+
+func (s *createdCheckpointState) Kill(ctx context.Context, sig uint32, all bool) error {
+	return s.p.kill(ctx, sig, all)
+}
+
+func (s *createdCheckpointState) SetExited(status int) {
+	s.p.setExited(status)
+
+	if err := s.transition("stopped"); err != nil {
+		panic(err)
+	}
+}
+
+func (s *createdCheckpointState) Exec(ctx context.Context, path string, r *ExecConfig) (Process, error) {
+	return nil, errors.Errorf("cannot exec in a created state")
+}
+
+func (s *createdCheckpointState) Status(ctx context.Context) (string, error) {
+	return "created", nil
+}
+
+type runningState struct {
+	p *Init
+}
+
+func (s *runningState) transition(name string) error {
+	switch name {
+	case "stopped":
+		s.p.initState = &stoppedState{p: s.p}
+	case "paused":
+		s.p.initState = &pausedState{p: s.p}
+	default:
+		return errors.Errorf("invalid state transition %q to %q", stateName(s), name)
+	}
+	return nil
+}
+
+func (s *runningState) Pause(ctx context.Context) error {
+	s.p.pausing.set(true)
+	// NOTE "pausing" will be returned in the short window
+	// after `transition("paused")`, before `pausing` is reset
+	// to false. That doesn't break the state machine, just
+	// delays the "paused" state a little bit.
+	defer s.p.pausing.set(false)
+
+	if err := s.p.runtime.Pause(ctx, s.p.id); err != nil {
+		return s.p.runtimeError(err, "OCI runtime pause failed")
+	}
+
+	return s.transition("paused")
+}
+
+func (s *runningState) Resume(ctx context.Context) error {
+	return errors.Errorf("cannot resume a running process")
+}
+
+func (s *runningState) Update(ctx context.Context, r *google_protobuf.Any) error {
+	return s.p.update(ctx, r)
+}
+
+func (s *runningState) Checkpoint(ctx context.Context, r *CheckpointConfig) error {
+	return s.p.checkpoint(ctx, r)
+}
+
+func (s *runningState) Start(ctx context.Context) error {
+	return errors.Errorf("cannot start a running process")
+}
+
+func (s *runningState) Delete(ctx context.Context) error {
+	return errors.Errorf("cannot delete a running process")
+}
+
+func (s *runningState) Kill(ctx context.Context, sig uint32, all bool) error {
+	return s.p.kill(ctx, sig, all)
+}
+
+func (s *runningState) SetExited(status int) {
+	s.p.setExited(status)
+
+	if err := s.transition("stopped"); err != nil {
+		panic(err)
+	}
+}
+
+func (s *runningState) Exec(ctx context.Context, path string, r *ExecConfig) (Process, error) {
+	return s.p.exec(ctx, path, r)
+}
+
+func (s *runningState) Status(ctx context.Context) (string, error) {
+	return "running", nil
+}
+
+type pausedState struct {
+	p *Init
+}
+
+func (s *pausedState) transition(name string) error {
+	switch name {
+	case "running":
+		s.p.initState = &runningState{p: s.p}
+	case "stopped":
+		s.p.initState = &stoppedState{p: s.p}
+	default:
+		return errors.Errorf("invalid state transition %q to %q", stateName(s), name)
+	}
+	return nil
+}
+
+func (s *pausedState) Pause(ctx context.Context) error {
+	return errors.Errorf("cannot pause a paused container")
+}
+
+func (s *pausedState) Resume(ctx context.Context) error {
+	if err := s.p.runtime.Resume(ctx, s.p.id); err != nil {
+		return s.p.runtimeError(err, "OCI runtime resume failed")
+	}
+
+	return s.transition("running")
+}
+
+func (s *pausedState) Update(ctx context.Context, r *google_protobuf.Any) error {
+	return s.p.update(ctx, r)
+}
+
+func (s *pausedState) Checkpoint(ctx context.Context, r *CheckpointConfig) error {
+	return s.p.checkpoint(ctx, r)
+}
+
+func (s *pausedState) Start(ctx context.Context) error {
+	return errors.Errorf("cannot start a paused process")
+}
+
+func (s *pausedState) Delete(ctx context.Context) error {
+	return errors.Errorf("cannot delete a paused process")
+}
+
+func (s *pausedState) Kill(ctx context.Context, sig uint32, all bool) error {
+	return s.p.kill(ctx, sig, all)
+}
+
+func (s *pausedState) SetExited(status int) {
+	s.p.setExited(status)
+
+	if err := s.p.runtime.Resume(context.Background(), s.p.id); err != nil {
+		logrus.WithError(err).Error("resuming exited container from paused state")
+	}
+
+	if err := s.transition("stopped"); err != nil {
+		panic(err)
+	}
+}
+
+func (s *pausedState) Exec(ctx context.Context, path string, r *ExecConfig) (Process, error) {
+	return nil, errors.Errorf("cannot exec in a paused state")
+}
+
+func (s *pausedState) Status(ctx context.Context) (string, error) {
+	return "paused", nil
+}
+
+type stoppedState struct {
+	p *Init
+}
+
+func (s *stoppedState) transition(name string) error {
+	switch name {
+	case "deleted":
+		s.p.initState = &deletedState{}
+	default:
+		return errors.Errorf("invalid state transition %q to %q", stateName(s), name)
+	}
+	return nil
+}
+
+func (s *stoppedState) Pause(ctx context.Context) error {
+	return errors.Errorf("cannot pause a stopped container")
+}
+
+func (s *stoppedState) Resume(ctx context.Context) error {
+	return errors.Errorf("cannot resume a stopped container")
+}
+
+func (s *stoppedState) Update(ctx context.Context, r *google_protobuf.Any) error {
+	return errors.Errorf("cannot update a stopped container")
+}
+
+func (s *stoppedState) Checkpoint(ctx context.Context, r *CheckpointConfig) error {
+	return errors.Errorf("cannot checkpoint a stopped container")
+}
+
+func (s *stoppedState) Start(ctx context.Context) error {
+	return errors.Errorf("cannot start a stopped process")
+}
+
+func (s *stoppedState) Delete(ctx context.Context) error {
+	if err := s.p.delete(ctx); err != nil {
+		return err
+	}
+	return s.transition("deleted")
+}
+
+func (s *stoppedState) Kill(ctx context.Context, sig uint32, all bool) error {
+	return s.p.kill(ctx, sig, all)
+}
+
+func (s *stoppedState) SetExited(status int) {
+	// no op
+}
+
+func (s *stoppedState) Exec(ctx context.Context, path string, r *ExecConfig) (Process, error) {
+	return nil, errors.Errorf("cannot exec in a stopped state")
+}
+
+func (s *stoppedState) Status(ctx context.Context) (string, error) {
+	return "stopped", nil
+}

--- a/process/io.go
+++ b/process/io.go
@@ -1,0 +1,385 @@
+//go:build !windows
+// +build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package process
+
+import (
+	"context"
+	"io"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/pkg/stdio"
+	runc "github.com/containerd/go-runc"
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
+	"github.com/projecteru2/systemd-runtime/tasklog"
+)
+
+const binaryIOProcTermTimeout = 12 * time.Second // Give logger process solid 10 seconds for cleanup
+
+var bufPool = sync.Pool{
+	New: func() interface{} {
+		// setting to 4096 to align with PIPE_BUF
+		// http://man7.org/linux/man-pages/man7/pipe.7.html
+		buffer := make([]byte, 4096)
+		return &buffer
+	},
+}
+
+type processIO struct {
+	io runc.IO
+
+	uri   *url.URL
+	copy  bool
+	stdio stdio.Stdio
+}
+
+func (p *processIO) Close() error {
+	if p.io != nil {
+		return p.io.Close()
+	}
+	return nil
+}
+
+func (p *processIO) IO() runc.IO {
+	return p.io
+}
+
+func (p *processIO) Copy(ctx context.Context, wg *sync.WaitGroup) error {
+	if !p.copy {
+		return nil
+	}
+	var cwg sync.WaitGroup
+	if err := copyPipes(ctx, p.IO(), p.stdio.Stdin, p.stdio.Stdout, p.stdio.Stderr, wg, &cwg); err != nil {
+		return errors.Wrap(err, "unable to copy pipes")
+	}
+	cwg.Wait()
+	return nil
+}
+
+func createIO(ctx context.Context, id string, ioUID, ioGID int, stdio stdio.Stdio) (*processIO, error) {
+	pio := &processIO{
+		stdio: stdio,
+	}
+	if stdio.IsNull() {
+		i, err := runc.NewNullIO()
+		if err != nil {
+			return nil, err
+		}
+		pio.io = i
+		return pio, nil
+	}
+	u, err := url.Parse(stdio.Stdout)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to parse stdout uri")
+	}
+	if u.Scheme == "" {
+		u.Scheme = "fifo"
+	}
+	pio.uri = u
+	switch u.Scheme {
+	case "fifo":
+		pio.copy = true
+		pio.io, err = runc.NewPipeIO(ioUID, ioGID, withConditionalIO(stdio))
+	case "binary":
+		pio.io, err = NewBinaryIO(ctx, id, u)
+	case "file":
+		filePath := u.Path
+		if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+			return nil, err
+		}
+		var f *os.File
+		f, err = os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			return nil, err
+		}
+		f.Close()
+		pio.stdio.Stdout = filePath
+		pio.stdio.Stderr = filePath
+		pio.copy = true
+		pio.io, err = runc.NewPipeIO(ioUID, ioGID, withConditionalIO(stdio))
+	default:
+		return nil, errors.Errorf("unknown STDIO scheme %s", u.Scheme)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return pio, nil
+}
+
+func copyPipes(ctx context.Context, rio runc.IO, _, stdout, stderr string, wg, cwg *sync.WaitGroup) error {
+	for _, i := range []struct {
+		name string
+		dest func(wc io.WriteCloser)
+	}{
+		{
+			name: stdout,
+			dest: func(wc io.WriteCloser) {
+				wg.Add(1)
+				cwg.Add(1)
+				go func() {
+					cwg.Done()
+					p := bufPool.Get().(*[]byte)
+					defer bufPool.Put(p)
+					if _, err := io.CopyBuffer(wc, rio.Stdout(), *p); err != nil {
+						log.G(ctx).Warn("error copying stdout")
+					}
+					wg.Done()
+					wc.Close()
+				}()
+			},
+		}, {
+			name: stderr,
+			dest: func(wc io.WriteCloser) {
+				wg.Add(1)
+				cwg.Add(1)
+				go func() {
+					cwg.Done()
+					p := bufPool.Get().(*[]byte)
+					defer bufPool.Put(p)
+					if _, err := io.CopyBuffer(wc, rio.Stderr(), *p); err != nil {
+						log.G(ctx).Warn("error copying stderr")
+					}
+					wg.Done()
+					wc.Close()
+				}()
+			},
+		},
+	} {
+		ok, err := tasklog.CheckOrCreateFifo(i.name)
+		if err != nil {
+			return errors.Wrapf(err, "containerd-shim: check or create w/o fifo %q failed", i.name)
+		}
+		if !ok {
+			logrus.Warnf("containerd-shim: the file %q may not be created properly", i.name)
+		}
+
+		fw, err := tasklog.NewLogger(i.name)
+		if err != nil {
+			return errors.Wrapf(err, "containerd-shim: opening w/o fifo %q failed", i.name)
+		}
+		i.dest(fw)
+		// todo support samefile
+	}
+	return nil
+}
+
+// NewBinaryIO runs a custom binary process for pluggable shim logging
+func NewBinaryIO(ctx context.Context, id string, uri *url.URL) (_ runc.IO, err error) {
+	ns, err := namespaces.NamespaceRequired(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var closers []func() error
+	defer func() {
+		if err == nil {
+			return
+		}
+		result := multierror.Append(err)
+		for _, fn := range closers {
+			result = multierror.Append(result, fn())
+		}
+		err = multierror.Flatten(result)
+	}()
+
+	out, err := newPipe()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create stdout pipes")
+	}
+	closers = append(closers, out.Close)
+
+	serr, err := newPipe()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create stderr pipes")
+	}
+	closers = append(closers, serr.Close)
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+	closers = append(closers, r.Close, w.Close)
+
+	cmd := NewBinaryCmd(uri, id, ns)
+	cmd.ExtraFiles = append(cmd.ExtraFiles, out.r, serr.r, w)
+	// don't need to register this with the reaper or wait when
+	// running inside a shim
+	if err := cmd.Start(); err != nil {
+		return nil, errors.Wrap(err, "failed to start binary process")
+	}
+	closers = append(closers, func() error { return cmd.Process.Kill() })
+
+	// close our side of the pipe after start
+	if err := w.Close(); err != nil {
+		return nil, errors.Wrap(err, "failed to close write pipe after start")
+	}
+
+	// wait for the logging binary to be ready
+	b := make([]byte, 1)
+	if _, err := r.Read(b); err != nil && err != io.EOF {
+		return nil, errors.Wrap(err, "failed to read from logging binary")
+	}
+
+	return &binaryIO{
+		cmd: cmd,
+		out: out,
+		err: serr,
+	}, nil
+}
+
+type binaryIO struct {
+	cmd      *exec.Cmd
+	out, err *pipe
+}
+
+func (b *binaryIO) CloseAfterStart() error {
+	var (
+		result *multierror.Error
+	)
+
+	for _, v := range []*pipe{b.out, b.err} {
+		if v != nil {
+			if err := v.r.Close(); err != nil {
+				result = multierror.Append(result, err)
+			}
+		}
+	}
+
+	return result.ErrorOrNil()
+}
+
+func (b *binaryIO) Close() error {
+	var (
+		result *multierror.Error
+	)
+
+	for _, v := range []*pipe{b.out, b.err} {
+		if v != nil {
+			if err := v.Close(); err != nil {
+				result = multierror.Append(result, err)
+			}
+		}
+	}
+
+	if err := b.cancel(); err != nil {
+		result = multierror.Append(result, err)
+	}
+
+	return result.ErrorOrNil()
+}
+
+func (b *binaryIO) cancel() error {
+	if b.cmd == nil || b.cmd.Process == nil {
+		return nil
+	}
+
+	// Send SIGTERM first, so logger process has a chance to flush and exit properly
+	if err := b.cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		result := multierror.Append(errors.Wrap(err, "failed to send SIGTERM"))
+
+		log.L.WithError(err).Warn("failed to send SIGTERM signal, killing logging shim")
+
+		if err := b.cmd.Process.Kill(); err != nil {
+			result = multierror.Append(result, errors.Wrap(err, "failed to kill process after faulty SIGTERM"))
+		}
+
+		return result.ErrorOrNil()
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- b.cmd.Wait()
+	}()
+
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(binaryIOProcTermTimeout):
+		log.L.Warn("failed to wait for shim logger process to exit, killing")
+
+		err := b.cmd.Process.Kill()
+		if err != nil {
+			return errors.Wrap(err, "failed to kill shim logger process")
+		}
+
+		return nil
+	}
+}
+
+func (b *binaryIO) Stdin() io.WriteCloser {
+	return nil
+}
+
+func (b *binaryIO) Stdout() io.ReadCloser {
+	return nil
+}
+
+func (b *binaryIO) Stderr() io.ReadCloser {
+	return nil
+}
+
+func (b *binaryIO) Set(cmd *exec.Cmd) {
+	if b.out != nil {
+		cmd.Stdout = b.out.w
+	}
+	if b.err != nil {
+		cmd.Stderr = b.err.w
+	}
+}
+
+func newPipe() (*pipe, error) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+	return &pipe{
+		r: r,
+		w: w,
+	}, nil
+}
+
+type pipe struct {
+	r *os.File
+	w *os.File
+}
+
+func (p *pipe) Close() error {
+	var result *multierror.Error
+
+	if err := p.w.Close(); err != nil {
+		result = multierror.Append(result, errors.Wrap(err, "failed to close write pipe"))
+	}
+
+	if err := p.r.Close(); err != nil {
+		result = multierror.Append(result, errors.Wrap(err, "failed to close read pipe"))
+	}
+
+	return multierror.Prefix(result.ErrorOrNil(), "pipe:")
+}

--- a/process/io_util.go
+++ b/process/io_util.go
@@ -1,0 +1,53 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package process
+
+import (
+	"net/url"
+	"os"
+	"os/exec"
+)
+
+// NewBinaryCmd returns a Cmd to be used to start a logging binary.
+// The Cmd is generated from the provided uri, and the container ID and
+// namespace are appended to the Cmd environment.
+func NewBinaryCmd(binaryURI *url.URL, id, ns string) *exec.Cmd {
+	var args []string
+	for k, vs := range binaryURI.Query() {
+		args = append(args, k)
+		if len(vs) > 0 {
+			args = append(args, vs[0])
+		}
+	}
+
+	cmd := exec.Command(binaryURI.Path, args...) //nolint:gosec
+
+	cmd.Env = append(cmd.Env,
+		"CONTAINER_ID="+id,
+		"CONTAINER_NAMESPACE="+ns,
+	)
+
+	return cmd
+}
+
+// CloseFiles closes any files passed in.
+// It it used for cleanup in the event of unexpected errors.
+func CloseFiles(files ...*os.File) {
+	for _, file := range files {
+		file.Close()
+	}
+}

--- a/process/process.go
+++ b/process/process.go
@@ -1,0 +1,56 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package process
+
+import (
+	"context"
+	"io"
+	"time"
+
+	"github.com/containerd/console"
+	"github.com/containerd/containerd/pkg/stdio"
+)
+
+// Process on a system
+type Process interface {
+	// ID returns the id for the process
+	ID() string
+	// Pid returns the pid for the process
+	Pid() int
+	// ExitStatus returns the exit status
+	ExitStatus() int
+	// ExitedAt is the time the process exited
+	ExitedAt() time.Time
+	// Stdin returns the process STDIN
+	Stdin() io.Closer
+	// Stdio returns io information for the container
+	Stdio() stdio.Stdio
+	// Status returns the process status
+	Status(context.Context) (string, error)
+	// Wait blocks until the process has exited
+	Wait()
+	// Resize resizes the process console
+	Resize(ws console.WinSize) error
+	// Start execution of the process
+	Start(context.Context) error
+	// Delete deletes the process and its resourcess
+	Delete(context.Context) error
+	// Kill kills the process
+	Kill(context.Context, uint32, bool) error
+	// SetExited sets the exit status for the process
+	SetExited(status int)
+}

--- a/process/types.go
+++ b/process/types.go
@@ -1,0 +1,66 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package process
+
+import (
+	google_protobuf "github.com/gogo/protobuf/types"
+)
+
+// Mount holds filesystem mount configuration
+type Mount struct {
+	Type    string
+	Source  string
+	Target  string
+	Options []string
+}
+
+// CreateConfig hold task creation configuration
+type CreateConfig struct {
+	ID               string
+	Bundle           string
+	Runtime          string
+	Rootfs           []Mount
+	Terminal         bool
+	Stdin            string
+	Stdout           string
+	Stderr           string
+	Checkpoint       string
+	ParentCheckpoint string
+	Options          *google_protobuf.Any
+}
+
+// ExecConfig holds exec creation configuration
+type ExecConfig struct {
+	ID       string
+	Terminal bool
+	Stdin    string
+	Stdout   string
+	Stderr   string
+	Spec     *google_protobuf.Any
+}
+
+// CheckpointConfig holds task checkpoint configuration
+type CheckpointConfig struct {
+	WorkDir                  string
+	Path                     string
+	Exit                     bool
+	AllowOpenTCP             bool
+	AllowExternalUnixSockets bool
+	AllowTerminal            bool
+	FileLocks                bool
+	EmptyNamespaces          []string
+}

--- a/process/utils.go
+++ b/process/utils.go
@@ -1,0 +1,203 @@
+//go:build !windows
+// +build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package process
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/containerd/containerd/errdefs"
+	runc "github.com/containerd/go-runc"
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	// RuncRoot is the path to the root runc state directory
+	RuncRoot = "/run/containerd/runc"
+	// InitPidFile name of the file that contains the init pid
+	InitPidFile = "init.pid"
+)
+
+// safePid is a thread safe wrapper for pid.
+type safePid struct {
+	sync.Mutex
+	pid int
+}
+
+func (s *safePid) get() int {
+	s.Lock()
+	defer s.Unlock()
+	return s.pid
+}
+
+type atomicBool int32
+
+func (ab *atomicBool) set(b bool) {
+	if b {
+		atomic.StoreInt32((*int32)(ab), 1)
+	} else {
+		atomic.StoreInt32((*int32)(ab), 0)
+	}
+}
+
+func (ab *atomicBool) get() bool {
+	return atomic.LoadInt32((*int32)(ab)) == 1
+}
+
+// TODO(mlaventure): move to runc package?
+func getLastRuntimeError(r *runc.Runc) (string, error) {
+	if r.Log == "" {
+		return "", nil
+	}
+
+	f, err := os.OpenFile(r.Log, os.O_RDONLY, 0400)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	var (
+		errMsg string
+		log    struct {
+			Level string
+			Msg   string
+			Time  time.Time
+		}
+	)
+
+	dec := json.NewDecoder(f)
+	for err = nil; err == nil; {
+		if err = dec.Decode(&log); err != nil && err != io.EOF {
+			return "", err
+		}
+		if log.Level == "error" {
+			errMsg = strings.TrimSpace(log.Msg)
+		}
+	}
+
+	return errMsg, nil
+}
+
+// criuError returns only the first line of the error message from criu
+// it tries to add an invalid dump log location when returning the message
+func criuError(err error) string {
+	parts := strings.Split(err.Error(), "\n")
+	return parts[0]
+}
+
+func copyFile(to, from string) error {
+	ff, err := os.Open(from)
+	if err != nil {
+		return err
+	}
+	defer ff.Close()
+	tt, err := os.Create(to)
+	if err != nil {
+		return err
+	}
+	defer tt.Close()
+
+	p := bufPool.Get().(*[]byte)
+	defer bufPool.Put(p)
+	_, err = io.CopyBuffer(tt, ff, *p)
+	return err
+}
+
+func checkKillError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if strings.Contains(err.Error(), "os: process already finished") ||
+		strings.Contains(err.Error(), "container not running") ||
+		strings.Contains(strings.ToLower(err.Error()), "no such process") ||
+		err == unix.ESRCH {
+		return errors.Wrapf(errdefs.ErrNotFound, "process already finished")
+	} else if strings.Contains(err.Error(), "does not exist") {
+		return errors.Wrapf(errdefs.ErrNotFound, "no such container")
+	}
+	return errors.Wrapf(err, "unknown error after kill")
+}
+
+func newPidFile(bundle string) *pidFile {
+	return &pidFile{
+		path: filepath.Join(bundle, InitPidFile),
+	}
+}
+
+func newExecPidFile(bundle, id string) *pidFile {
+	return &pidFile{
+		path: filepath.Join(bundle, fmt.Sprintf("%s.pid", id)),
+	}
+}
+
+type pidFile struct {
+	path string
+}
+
+func (p *pidFile) Path() string {
+	return p.path
+}
+
+func (p *pidFile) Read() (int, error) {
+	return runc.ReadPidFile(p.path)
+}
+
+// waitTimeout handles waiting on a waitgroup with a specified timeout.
+// this is commonly used for waiting on IO to finish after a process has exited
+func waitTimeout(ctx context.Context, wg *sync.WaitGroup, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func stateName(v interface{}) string {
+	switch v.(type) {
+	case *runningState, *execRunningState:
+		return "running"
+	case *createdState, *execCreatedState, *createdCheckpointState:
+		return "created"
+	case *pausedState:
+		return "paused"
+	case *deletedState:
+		return "deleted"
+	case *stoppedState:
+		return "stopped"
+	}
+	panic(errors.Errorf("invalid state %v", v))
+}

--- a/runc/container.go
+++ b/runc/container.go
@@ -33,12 +33,13 @@ import (
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/namespaces"
-	"github.com/containerd/containerd/pkg/process"
 	"github.com/containerd/containerd/pkg/stdio"
 	"github.com/containerd/containerd/runtime/v2/runc/options"
 	"github.com/containerd/containerd/runtime/v2/task"
 	"github.com/containerd/typeurl"
 	ptypes "github.com/gogo/protobuf/types"
+
+	"github.com/projecteru2/systemd-runtime/process"
 )
 
 // NewContainer returns a new runc container

--- a/runc/platform.go
+++ b/runc/platform.go
@@ -26,10 +26,11 @@ import (
 
 	"github.com/containerd/console"
 	"github.com/containerd/containerd/namespaces"
-	"github.com/containerd/containerd/pkg/process"
 	"github.com/containerd/containerd/pkg/stdio"
 	"github.com/containerd/fifo"
 	"github.com/pkg/errors"
+
+	"github.com/projecteru2/systemd-runtime/process"
 )
 
 var bufPool = sync.Pool{
@@ -197,3 +198,7 @@ func (p *linuxPlatform) ShutdownConsole(ctx context.Context, cons console.Consol
 func (p *linuxPlatform) Close() error {
 	return p.epoller.Close()
 }
+
+// func openFifo(ctx context.Context, fn string, flag int, perm os.FileMode) (io.ReadWriteCloser, error) {
+// 	return fifo.OpenFifo(ctx, fn, flag, perm)
+// }

--- a/shim/rpc.go
+++ b/shim/rpc.go
@@ -25,11 +25,12 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/containerd/containerd/errdefs"
-	"github.com/containerd/containerd/pkg/process"
 	"github.com/containerd/containerd/runtime/v2/runc/options"
 	taskAPI "github.com/containerd/containerd/runtime/v2/task"
 	"github.com/containerd/typeurl"
 	ptypes "github.com/gogo/protobuf/types"
+
+	"github.com/projecteru2/systemd-runtime/process"
 )
 
 var (

--- a/shim/service.go
+++ b/shim/service.go
@@ -29,12 +29,12 @@ import (
 	eventstypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/api/types/task"
 	"github.com/containerd/containerd/errdefs"
-	"github.com/containerd/containerd/pkg/process"
 	"github.com/containerd/containerd/runtime"
 	"github.com/containerd/containerd/runtime/v2/runc/options"
 	"github.com/containerd/typeurl"
 	ptypes "github.com/gogo/protobuf/types"
 
+	"github.com/projecteru2/systemd-runtime/process"
 	"github.com/projecteru2/systemd-runtime/runc"
 )
 

--- a/shim/shim.go
+++ b/shim/shim.go
@@ -44,7 +44,6 @@ import (
 	"github.com/containerd/containerd/pkg/oom"
 	oomv1 "github.com/containerd/containerd/pkg/oom/v1"
 	oomv2 "github.com/containerd/containerd/pkg/oom/v2"
-	"github.com/containerd/containerd/pkg/process"
 	"github.com/containerd/containerd/pkg/stdio"
 	cruntime "github.com/containerd/containerd/runtime"
 	shimapi "github.com/containerd/containerd/runtime/v2/task"
@@ -56,6 +55,7 @@ import (
 	"github.com/containerd/ttrpc"
 
 	"github.com/projecteru2/systemd-runtime/common"
+	"github.com/projecteru2/systemd-runtime/process"
 	"github.com/projecteru2/systemd-runtime/runc"
 )
 

--- a/task/task.go
+++ b/task/task.go
@@ -87,9 +87,15 @@ func (t *Task) State(ctx context.Context) (state runtime.State, err error) {
 				Status: runtime.CreatedStatus,
 			}, nil
 		}
-		// other wise we return pasued
+		// other wise we return pasued, and we must return stdout here
+		opts, err := t.bundle.LoadOpts(ctx)
+		if err != nil {
+			return state, err
+		}
 		return runtime.State{
 			Status: runtime.PausedStatus,
+			Stdout: opts.IO.Stdout,
+			Stderr: opts.IO.Stderr,
 		}, nil
 	}
 

--- a/tasklog/cachedlog.go
+++ b/tasklog/cachedlog.go
@@ -1,0 +1,118 @@
+package tasklog
+
+import (
+	"io"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+)
+
+const LIMIT = 1024
+
+type cachedLog struct {
+	sync.Mutex
+	buff   []byte
+	buffer [][]byte
+}
+
+func (log *cachedLog) HasCachedContent() bool {
+	log.Lock()
+	defer log.Unlock()
+
+	return log.buff != nil || len(log.buffer) > 0
+}
+
+func (log *cachedLog) Pipe(w io.Writer) error {
+	ch := make(chan []byte)
+	next := make(chan struct{})
+	closed := make(chan struct{})
+
+	go func() {
+		defer close(ch)
+		defer close(next)
+		defer close(closed)
+
+		for {
+			buffer := func() []byte {
+				log.Lock()
+				defer log.Unlock()
+				if log.buff != nil {
+					return log.buff
+				}
+
+				if len(log.buffer) == 0 {
+					return nil
+				}
+				buffer := log.buffer[0]
+				log.buff = buffer
+				log.buffer = log.buffer[1:]
+
+				return buffer
+			}()
+
+			if buffer == nil {
+				return
+			}
+
+			ch <- buffer
+			select {
+			case <-next:
+			case <-closed:
+				return
+			}
+		}
+	}()
+
+	for buffer := range ch {
+		cnt, err := w.Write(buffer)
+		if err == nil {
+			func() {
+				log.Lock()
+				defer log.Unlock()
+
+				log.buff = nil
+			}()
+			next <- struct{}{}
+			continue
+		}
+
+		buffer = buffer[cnt:]
+		func() {
+			log.Lock()
+			defer log.Unlock()
+
+			if len(buffer) > 0 {
+				log.buff = buffer
+				return
+			}
+			log.buff = nil
+		}()
+		closed <- struct{}{}
+		return err
+	}
+
+	logrus.Debug("cached content has all been piped")
+	return nil
+}
+
+func (log *cachedLog) Write(b []byte) (int, error) {
+	log.Lock()
+	defer log.Unlock()
+
+	size := len(log.buffer)
+	if size >= LIMIT {
+		log.buffer = append(log.buffer[size-LIMIT+1:], b)
+	} else {
+		log.buffer = append(log.buffer, b)
+	}
+
+	return len(b), nil
+}
+
+func (log *cachedLog) Close() error {
+	return nil
+}
+
+func (log *cachedLog) Reset() error {
+	return nil
+}

--- a/tasklog/errors.go
+++ b/tasklog/errors.go
@@ -1,0 +1,24 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package tasklog
+
+import "errors"
+
+var (
+	// ErrFifoClosed .
+	ErrFifoClosed = errors.New("fifo closed")
+)

--- a/tasklog/fifo.go
+++ b/tasklog/fifo.go
@@ -1,0 +1,193 @@
+//go:build !windows
+// +build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package tasklog
+
+import (
+	"io"
+	"os"
+	"sync"
+	"syscall"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+type OnResetComplete func(io.Writer, ResetCloser)
+type ResetCloser interface {
+	io.Closer
+	Reset(OnResetComplete)
+}
+
+func newFifoHolder(fn string, s OnResetComplete) (holder *fifoHolder, err error) {
+	if _, err := os.Stat(fn); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+		if err := syscall.Mkfifo(fn, 0); err != nil && !os.IsExist(err) {
+			return nil, errors.Wrapf(err, "error creating fifo %v", fn)
+		}
+	}
+
+	holder = &fifoHolder{
+		fn:          fn,
+		subscribers: []OnResetComplete{s},
+	}
+
+	go func() {
+		fifo, err := openFifo(holder.fn)
+		holder.set(fifo, err)
+	}()
+
+	return holder, nil
+}
+
+type fifoHolder struct {
+	sync.Mutex
+	fn          string
+	closed      bool
+	fifo        io.WriteCloser
+	err         error
+	subscribers []OnResetComplete
+}
+
+func (holder *fifoHolder) get() (io.WriteCloser, error) {
+	holder.Lock()
+	defer holder.Unlock()
+	return holder.fifo, holder.err
+}
+
+func (holder *fifoHolder) set(wc io.WriteCloser, err error) {
+	subscribers := func() []OnResetComplete {
+		holder.Lock()
+		defer holder.Unlock()
+		holder.fifo = wc
+		holder.err = err
+
+		subscibers := holder.subscribers
+		holder.subscribers = nil
+		return subscibers
+	}()
+	if err == nil {
+		for _, subscriber := range subscribers {
+			subscriber(wc, holder)
+		}
+	}
+}
+
+func (holder *fifoHolder) holderClosed() bool {
+	holder.Lock()
+	defer holder.Unlock()
+
+	return holder.closed
+}
+
+func (holder *fifoHolder) Reset(s OnResetComplete) {
+	holder.Lock()
+	defer holder.Unlock()
+
+	holder.subscribers = append(holder.subscribers, s)
+
+	fifo := holder.fifo
+	holder.fifo = nil
+	holder.err = nil
+
+	go func() {
+		var err error
+		if err = fifo.Close(); err != nil {
+			logrus.Errorf("close fifo error, cause: %v", err)
+		}
+		fifo, err = openFifo(holder.fn)
+		if holder.holderClosed() {
+			_ = fifo.Close()
+			return
+		}
+		holder.set(fifo, err)
+	}()
+}
+
+func (holder *fifoHolder) Close() error {
+	holder.Lock()
+	defer holder.Unlock()
+
+	if holder.closed {
+		return nil
+	}
+
+	holder.subscribers = nil
+	holder.closed = true
+	holder.err = ErrFifoClosed
+	if holder.fifo != nil {
+		_ = holder.fifo.Close()
+	}
+
+	return nil
+}
+
+func openFifo(fn string) (f *fifo, err error) {
+	logrus.Debugf("open fifo for task log %s", fn)
+	var (
+		handle *handle
+		path   string
+	)
+	handle, err = getHandle(fn)
+	if err != nil {
+		logrus.Errorf("get fifo handle for task log error, %s, cause = %v", fn, err)
+		return nil, err
+	}
+
+	defer func() {
+		if err != nil {
+			logrus.Errorf("open fifo for task log error, %s, cause = %v", fn, err)
+			_ = handle.Close()
+		}
+	}()
+	path, err = handle.Path()
+	if err != nil {
+		return nil, err
+	}
+
+	file, err := os.OpenFile(path, syscall.O_WRONLY, 0)
+	if err != nil {
+		return nil, err
+	}
+	logrus.Debugf("open fifo for task log success %s", fn)
+	return &fifo{
+		file:    file,
+		handler: handle,
+	}, nil
+}
+
+type fifo struct {
+	once    sync.Once
+	file    *os.File
+	handler *handle
+}
+
+func (f *fifo) Write(b []byte) (int, error) {
+	return f.file.Write(b)
+}
+
+func (f *fifo) Close() error {
+	_ = f.handler.Close()
+	f.once.Do(func() {
+		_ = f.file.Close()
+	})
+	return nil
+}

--- a/tasklog/handle.go
+++ b/tasklog/handle.go
@@ -1,0 +1,106 @@
+//go:build linux
+// +build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package tasklog
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"syscall"
+
+	"github.com/pkg/errors"
+)
+
+//nolint:revive
+const O_PATH = 010000000
+
+type handle struct {
+	f         *os.File
+	fd        uintptr
+	dev       uint64
+	ino       uint64
+	closeOnce sync.Once
+	name      string
+}
+
+func getHandle(fn string) (*handle, error) {
+	f, err := os.OpenFile(fn, O_PATH, 0)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to open %v with O_PATH", fn)
+	}
+
+	var (
+		stat syscall.Stat_t
+		fd   = f.Fd()
+	)
+	if err := syscall.Fstat(int(fd), &stat); err != nil {
+		_ = f.Close()
+		return nil, errors.Wrapf(err, "failed to stat handle %v", fd)
+	}
+
+	if stat.Mode&syscall.S_IFIFO != syscall.S_IFIFO {
+		_ = f.Close()
+		return nil, errors.Errorf("file %s is not fifo", fn)
+	}
+
+	h := &handle{
+		f:    f,
+		name: fn,
+		//nolint:unconvert
+		dev: uint64(stat.Dev),
+		ino: stat.Ino,
+		fd:  fd,
+	}
+
+	// check /proc just in case
+	if _, err := os.Stat(h.procPath()); err != nil {
+		f.Close()
+		return nil, errors.Wrapf(err, "couldn't stat %v", h.procPath())
+	}
+
+	return h, nil
+}
+
+func (h *handle) procPath() string {
+	return fmt.Sprintf("/proc/self/fd/%d", h.fd)
+}
+
+func (h *handle) Name() string {
+	return h.name
+}
+
+func (h *handle) Path() (string, error) {
+	var stat syscall.Stat_t
+	if err := syscall.Stat(h.procPath(), &stat); err != nil {
+		return "", errors.Wrapf(err, "path %v could not be statted", h.procPath())
+	}
+	//nolint:unconvert
+	if uint64(stat.Dev) != h.dev || stat.Ino != h.ino {
+		return "", errors.Errorf("failed to verify handle %v/%v %v/%v", stat.Dev, h.dev, stat.Ino, h.ino)
+	}
+	return h.procPath(), nil
+}
+
+func (h *handle) Close() error {
+	h.closeOnce.Do(func() {
+		h.f.Close()
+	})
+	return nil
+}

--- a/tasklog/tasklog.go
+++ b/tasklog/tasklog.go
@@ -1,0 +1,97 @@
+package tasklog
+
+import (
+	"io"
+
+	"github.com/sirupsen/logrus"
+)
+
+// CachedLog .
+type CachedLog interface {
+	io.WriteCloser
+	HasCachedContent() bool
+	Pipe(io.Writer) error
+	Reset() error
+}
+
+type taskLog struct {
+	fifo      *fifoHolder
+	cachedLog CachedLog
+}
+
+// NewLogger .
+func NewLogger(fn string) (io.WriteCloser, error) {
+	cachedLog := &cachedLog{}
+	fifo, err := newFifoHolder(fn, func(resetW io.Writer, resetRC ResetCloser) {
+		if cachedLog.HasCachedContent() {
+			onNamedPipeReady(resetW, resetRC, cachedLog)
+		}
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &taskLog{
+		fifo:      fifo,
+		cachedLog: cachedLog,
+	}, nil
+}
+
+func (log *taskLog) Write(b []byte) (int, error) {
+	if log.cachedLog.HasCachedContent() {
+		logrus.Debug("has cached content, writing to cached content")
+		return log.cachedLog.Write(b)
+	}
+
+	fifo, err := log.fifo.get()
+	if err != nil {
+		logrus.Errorf("fifo has closed, cause = %v", err)
+		return 0, err
+	}
+	if fifo != nil {
+		logrus.Debug("write log content to fifo")
+		cnt, err := fifo.Write(b)
+		if err == nil {
+			return cnt, nil
+		}
+		if err != nil {
+			logrus.Warnf("write fifo error, reset fifo, cause = %v", err)
+			log.fifo.Reset(func(resetW io.Writer, resetRC ResetCloser) {
+				onNamedPipeReady(resetW, resetRC, log.cachedLog)
+			})
+		}
+		b = b[cnt:]
+	}
+	return log.cachedLog.Write(b)
+}
+
+func (log *taskLog) Close() error {
+	_ = log.fifo.Close()
+	_ = log.cachedLog.Close()
+	return nil
+}
+
+func onNamedPipeReady(w io.Writer, resetCloser ResetCloser, cachedLog CachedLog) {
+	logrus.Debug("named pipe is ready, prepare pipe cached content to fifo")
+	go func() {
+		for {
+			err := cachedLog.Pipe(w)
+			if err == nil {
+				return
+			}
+			if err == ErrFifoClosed {
+				logrus.Warnf("fifo is closed when pipe cached content to fifo error, will try reset fifo")
+				resetCloser.Reset(func(resetW io.Writer, resetRC ResetCloser) {
+					onNamedPipeReady(resetW, resetRC, cachedLog)
+				})
+				return
+			}
+			logrus.Warnf("pipe cached content to fifo error, cause = %v", err)
+			if err := cachedLog.Reset(); err != nil {
+				logrus.Errorf("reset cached log error, cause = %v", err)
+				_ = resetCloser.Close()
+				_ = cachedLog.Close()
+				return
+			}
+		}
+	}()
+}

--- a/tasklog/utils.go
+++ b/tasklog/utils.go
@@ -1,0 +1,78 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package tasklog
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// IsFifo checks if a file is a (named pipe) fifo
+// if the file does not exist then it returns false
+func IsFifo(path string) (bool, error) {
+	stat, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if stat.Mode()&os.ModeNamedPipe == os.ModeNamedPipe {
+		return true, nil
+	}
+	return false, nil
+}
+
+// CheckOrCreateFifo .
+func CheckOrCreateFifo(path string) (bool, error) {
+	for retry := 3; ; retry-- {
+		ok, err := isFifo(path)
+		if err == nil || !os.IsNotExist(err) {
+			return ok, err
+		}
+		if retry <= 0 {
+			return false, nil
+		}
+		// file is not exist, we will try create fifo file
+		if err = mkFifo(path); err == nil {
+			return true, nil
+		}
+		if !os.IsExist(err) {
+			// mk fifo error, return
+			return false, err
+		}
+	}
+}
+
+func mkFifo(p string) error {
+	if err := os.MkdirAll(filepath.Dir(p), os.ModePerm); err != nil {
+		return err
+	}
+	return syscall.Mkfifo(p, uint32(os.ModePerm))
+}
+
+func isFifo(path string) (bool, error) {
+	stat, err := os.Stat(path)
+	if err != nil {
+		return false, err
+	}
+	if stat.Mode()&os.ModeNamedPipe == os.ModeNamedPipe {
+		return true, nil
+	}
+	return false, nil
+}


### PR DESCRIPTION
In this pr, the log forwarding to dockerd by fifo is repaired.  The fifo file is restored on startup, and shim will check whether the fifo is open and write to log file when fifo isn't opened by dockerd.